### PR TITLE
Add option to wrap text on hosts/services columns.

### DIFF
--- a/centreon_report_to_pdf/BuildPDF.py
+++ b/centreon_report_to_pdf/BuildPDF.py
@@ -446,13 +446,29 @@ def build_table_details():
         subhead = [['', '', '%', 'Alert', '%', 'Alert',
                     '%', 'Alert', '%', 'Alert', 'Downtimes', '%']]
 
+        for index, row in data_df.iterrows():
+            data_df.loc[index, 'Host'] = Paragraph(
+                str(row['Host']), styleNormal)
+            data_df.loc[index, 'Service'] = Paragraph(
+                str(row['Service']), styleNormal)
+
         # Conact the header + sub_header and data to list
         data_list = [data_df.columns.values.tolist()] + list(subhead) + \
             data_df.values.tolist()
 
+        # Get the value of the column size for the host and service
+        if GlobalVars.column_size_host == 'auto' or GlobalVars.column_size_service == 'auto':
+            columns_table_sizes = ['*', '*',  10*mm,  10*mm,  10*mm,
+                                   10*mm,  10*mm,  10*mm, 10*mm,  10*mm,  20*mm,  20*mm]
+        # if not setup, put it on automatically (default)
+        else:
+            columns_table_sizes = [GlobalVars.column_size_host*mm, GlobalVars.column_size_service *
+                                   mm,  10*mm,  10*mm,  10*mm,  10*mm,  10*mm,  10*mm, 10*mm,  10*mm,  20*mm,  20*mm]
+
         # Generate the table using the list and repeat the headers if necesary
-        table = Table(data=data_list,  repeatRows=2,  colWidths=[
-                      '*', '*',  10*mm,  10*mm,  10*mm,  10*mm,  10*mm,  10*mm, 10*mm,  10*mm,  20*mm,  20*mm])
+        # Fixed hosts/services columns values are need to allow paragraph text wrap works correctly if there is no spaces.
+        table = Table(data=data_list,  repeatRows=2,
+                      colWidths=columns_table_sizes)
 
         # Apply some styles to table and cells
         table.setStyle(styleTable)

--- a/centreon_report_to_pdf/GlobalVars.py
+++ b/centreon_report_to_pdf/GlobalVars.py
@@ -13,6 +13,8 @@ custom_period_end = None
 pdf_output_file = 'centreon_report.pdf'
 csv_download_filepath = '/tmp/centreon.csv'
 sort_data_by_name = True
+column_size_host = 'auto'
+column_size_service = 'auto'
 
 # [REPORTS_ID]
 hosts_groups = [0]

--- a/centreon_report_to_pdf/Settings.py
+++ b/centreon_report_to_pdf/Settings.py
@@ -651,3 +651,18 @@ def get_command_line_args():
             'REPORT', 'sort_data_by_name')
     except:
         pass
+
+    # Get the value of the column size for the host
+    try:
+        GlobalVars.column_size_host = config.getint(
+            'REPORT', 'column_size_host')
+
+    except:
+        pass
+
+    # Get the value of the column size for the service
+    try:
+        GlobalVars.column_size_service = config.getint(
+            'REPORT', 'column_size_service')
+    except:
+        pass

--- a/centreon_report_to_pdf/config_example.ini
+++ b/centreon_report_to_pdf/config_example.ini
@@ -5,7 +5,7 @@ server_url = https://yourserver.com/centreon/
 autologin_url = https://yourserver.com/centreon/main.php?autologin=1&useralias=YOUR_ALIAS&token=YOURTOKEN
 ; user = your_user
 ; password = yOur pas$w0d
-# SSL verification: It is a bad idea disable it because will make your application vulnerable to 
+# SSL verification: It is a bad idea disable it because will make your application vulnerable to
 # man-in-the-middle (MitM) attacks, but centreon maybe have a autosign or expired certificates. :-(
 verify_ssl = True
 # Proxy settings (Optional)
@@ -17,15 +17,19 @@ Timezone = America/Santiago
 
 [REPORT]
 # Some valid values to period: 'yesterday', 'this_week', 'last_week', 'this_month', 'last_month', 'this_year' 'last_year', 'custom'
-# If 'custom' is set, you need to define 'custom_period_start' and 'custom_period_start' too. 
+# If 'custom' is set, you need to define 'custom_period_start' and 'custom_period_start' too.
 # Examples: 24/03/2020 - 15/Jan/2020 - 2020/17/03 - 02-15-2022
-period=last_month 
+period=last_month
 custom_period_start = 01/25/20
 custom_period_end = 13/march/2020
 pdf_output_file = /tmp/centreon_report_VHS.pdf
 csv_download_filepath = /tmp/centreon.csv
 # Sort data by Host and Service name ascending or by OK/UP descending (to get focus in the worse first).
 sort_data_by_name = True
+# Set the size of the columns host and service. Change it if you have long host/services names without space ("-" or "_" for example)
+column_size_host = 38
+column_size_service = 38
+
 
 [REPORTS_ID]
 # The list of Host and Service Groups IDs that you want process.
@@ -52,7 +56,7 @@ email_password = Y0ur emai1 P1ssword Here@#$%
 
 
 # Option to include or not a Cover Page
-# the logo size can be great than 100x50 
+# the logo size can be great than 100x50
 # the text line can't be more than 50 carachters long.
 # extra_info is only the actual date and the server URL
 [COVER]
@@ -63,7 +67,7 @@ cover_logo_size_y = 50
 cover_title_1 = Availability Report
 cover_title_2 = Your Company Name Here
 cover_text_1 = Some text or description here
-cover_text_2 = 
+cover_text_2 =
 cover_extra_info = true
 # date format examples : %b/%d/%Y - %c - %d/%m/%y (%A) - Report Week Number: %w
 # https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes


### PR DESCRIPTION
## What:
Resolve Issue #8 

## Changelog
* Included option to wrap the text of the hosts and services
* Included variables **column_size_service** and **column_size_host** to allow users change the size of the columns from automatic to a specific value on the INI configuration file. *Note: This is necessary if the host/service name are long and don't have spaces on it.*